### PR TITLE
Add IInitializeWithWindow(), which is required for desktop apps

### DIFF
--- a/source/dwinrt/package.d
+++ b/source/dwinrt/package.d
@@ -1307,6 +1307,12 @@ auto make(T, Args...)(Args args)
 	}
 }
 
+@uuid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")
+interface IInitializeWithWindow : IUnknown
+{
+	HRESULT Initialize(HWND hwnd);
+}
+
 enum bitflags;
 
 public static import Windows.Foundation.Collections;


### PR DESCRIPTION
Add InitializeWithWindow.Initialize() that is a basically method for desktop apps such as [DFL with D/WinRT](https://github.com/Rayerd/dfl/blob/e05dc727103a5131d142a34ab32596b97d5196cd/examples/dfl_with_dwinrt/source/app.d).