### PR TITLE
Fix hstring opAssign

### DIFF
--- a/source/dwinrt/package.d
+++ b/source/dwinrt/package.d
@@ -287,6 +287,8 @@ struct hstring
 
 	ref hstring opAssign(ref hstring value)
 	{
+		if (m_handle)
+			delete_string(m_handle);
 		m_handle = duplicate_string(value.m_handle);
 		return this;
 	}


### PR DESCRIPTION
When you assign an hstring, the HSTRING that the lvalue originally had is leaked.